### PR TITLE
Fix environment variable substitution loop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
 script: 
 - flake8 --version
 - flake8 c2c --max-line-length=100
-- python setup.py nosetests -a '!template'
+- python setup.py nosetests
 
 after_success:
 - pip install coveralls

--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,8 @@ Supported template Jinja, Mako, Template.
 
 Tools that collect some vars and get them to a template engine.
 
-Supported template: `Jinja <http://jinja.pocoo.org/>`_,
-`Mako <http://www.makotemplates.org/>`_ and
-`Template <https://pypi.python.org/pypi/z3c.recipe.filetemplate>`_.
+Supported template: `Jinja <http://jinja.pocoo.org/>`_ and
+`Mako <http://www.makotemplates.org/>`_.
 
 Use ``c2c-template --help`` to get the command line help.
 

--- a/c2c/template.py
+++ b/c2c/template.py
@@ -353,7 +353,7 @@ def read_vars(vars_file):
                     def action(expression):
                         try:
                             return eval(expression, globs)
-                        except:  # pragma: nocover
+                        except Exception:  # pragma: nocover
                             error = "ERROR when evaluating {} expression {} as Python:\n{}".format(
                                 var_name, expression, traceback.format_exc()
                             )

--- a/c2c/template.py
+++ b/c2c/template.py
@@ -38,7 +38,7 @@ from yaml.parser import ParserError
 from argparse import ArgumentParser
 from string import Formatter
 from subprocess import CalledProcessError
-from six import string_types, text_type
+from six import string_types
 try:
     from subprocess import check_output
 except ImportError:  # pragma: nocover
@@ -92,7 +92,7 @@ def main():
         description='Used to run a template'
     )
     parser.add_argument(
-        '--engine', '-e', choices=['jinja', 'mako', 'template'], default='jinja',
+        '--engine', '-e', choices=['jinja', 'mako'], default='jinja',
         help='the used template engine'
     )
     parser.add_argument(
@@ -277,32 +277,6 @@ def _proceed(files, used_vars, options):
     elif options.engine == 'mako':
         from bottle import mako_template as engine
         bottle_template(files, used_vars, engine)
-
-    elif options.engine == 'template':  # pragma: nocover
-        for template, destination in files:
-            c2c_template = C2cTemplate(
-                template,
-                template,
-                used_vars
-            )
-            c2c_template.section = options.section
-            processed = text_type(c2c_template.substitute(), "utf8")
-            save(template, destination, processed)
-
-
-try:
-    from z3c.recipe.filetemplate import Template
-
-    class C2cTemplate(Template):  # pragma: nocover
-        def _get(self, section, option, start):
-            if self.section and section is not None:
-                return self.recipe[section][option]
-            else:
-                return self.recipe[option]
-except ImportError:
-    class C2cTemplate:
-        def __init__(self, *args):  # pragma: nocover
-            raise Exception("The egg 'z3c.recipe.filetemplate' is missing.")
 
 
 def bottle_template(files, used_vars, engine):

--- a/c2c/template.py
+++ b/c2c/template.py
@@ -34,6 +34,7 @@ import traceback
 import re
 import json
 import yaml
+import itertools
 from yaml.parser import ParserError
 from argparse import ArgumentParser
 from string import Formatter
@@ -80,11 +81,12 @@ def transform_path(value, path, action):
 def get_config(file_name):
     with open(file_name) as f:
         config = yaml.safe_load(f.read())
-    vars_ = config["vars"]
-    for var in config.get("environment", []):
-        var_path = dot_split(var)
-        transform_path(vars_, var_path, lambda v: v.format(**os.environ))
-    return vars_
+    format_walker = FormatWalker(
+        config["vars"],
+        config.get("environment", [])
+    )
+    format_walker()
+    return format_walker.used_vars
 
 
 def main():
@@ -132,7 +134,83 @@ def main():
         metavar='ARG', help=files_builder_help
     )
     options = parser.parse_args()
+    do(options)
 
+
+class FormatWalker:
+    formatter = Formatter()
+
+    def __init__(self, used_vars, environment, runtime_environment=None):
+        self.formatted = []
+        self.used_vars = used_vars
+        self.environment = environment
+        self.runtime_environment = runtime_environment
+
+        if runtime_environment is None:
+            runtime_environment = []
+
+        self.all_environment_dict = {}
+        for env in environment:
+            self.all_environment_dict[env] = os.environ[env]
+        for env in runtime_environment:
+            self.all_environment_dict[env] = '{' + env + '}'
+
+    def format_walker(self, current_vars, path=None):
+        if isinstance(current_vars, string_types):
+            if path not in self.formatted:
+                attrs = self.formatter.parse(current_vars)
+                for _, attr, _, _ in attrs:
+                    if attr is not None \
+                            and attr not in self.formatted \
+                            and attr not in self.environment \
+                            and attr not in self.runtime_environment:
+                        return current_vars, [[path, attr]]
+                self.formatted.append(path)
+                vars_ = {}
+                vars_.update(self.all_environment_dict)
+                vars_.update(self.used_vars)
+                return current_vars.format(**vars_), []
+            return current_vars, []
+
+        elif isinstance(current_vars, list):
+            formatteds = [
+                self.format_walker(var, "{}[{}]".format(path, index))
+                for index, var in enumerate(current_vars)
+            ]
+            return [v for v, s in formatteds], list(itertools.chain(*[s for v, s in formatteds]))
+
+        elif isinstance(current_vars, dict):
+            skip = []
+            for key in current_vars.keys():
+                if path is None:
+                    current_path = key
+                else:
+                    current_path = u"{}[{}]".format(path, key)
+                current_formatted = self.format_walker(current_vars[key], current_path)
+                current_vars[key] = current_formatted[0]
+                skip += current_formatted[1]
+            return current_vars, skip
+        else:
+            self.formatted.append(path)
+
+        return current_vars, []
+
+    def __call__(self):
+        skip = None
+        old_skip = sys.maxsize
+        while skip is None or old_skip != len(skip) and len(skip) != 0:
+            old_skip = sys.maxsize if skip is None else len(skip)
+            self.used_vars, skip = self.format_walker(self.used_vars)
+
+        if len(skip) > 0:
+            print(
+                "The following variable isn't correctly interpreted due missing dependency:\n" +
+                "\n".join(["'{}' depend on '{}'.".format(*e) for e in skip])
+            )
+            sys.exit(1)
+
+
+def do(options):
     if options.cache is not None and options.vars is not None:
         print("The --vars and --cache options cannot be used together.")
         exit(1)
@@ -148,47 +226,13 @@ def main():
     else:
         used_vars, config = read_vars(options.vars)
 
-        formatter = Formatter()
-        formatted = []
-
-        def format_walker(current_vars, path=None):
-            if isinstance(current_vars, string_types):
-                if path not in formatted:
-                    attrs = formatter.parse(current_vars)
-                    for _, attr, _, _ in attrs:
-                        if attr is not None and attr not in formatted:
-                            return current_vars, 1
-                    formatted.append(path)
-                    return current_vars.format(**used_vars), 0
-                return current_vars, 0
-
-            elif isinstance(current_vars, list):
-                formatteds = [
-                    format_walker(var, "{0!s}[{1:d}]".format(path, index))
-                    for index, var in enumerate(current_vars)
-                ]
-                return [v for v, s in formatteds], sum([s for v, s in formatteds])
-
-            elif isinstance(current_vars, dict):
-                skip = 0
-                for key in current_vars.keys():
-                    if path is None:
-                        current_path = key
-                    else:
-                        current_path = u"{0!s}[{1!s}]".format(path, key)
-                    current_formatted = format_walker(current_vars[key], current_path)
-                    current_vars[key] = current_formatted[0]
-                    skip += current_formatted[1]
-                return current_vars, skip
-            else:
-                formatted.append(path)
-
-            return current_vars, 0
-        old_skip = 0
-        skip = -1
-        while old_skip != skip and skip != 0:
-            old_skip = skip
-            used_vars, skip = format_walker(used_vars)
+        format_walker = FormatWalker(
+            used_vars,
+            config.get("environment", []),
+            config.get("runtime_environment", [])
+        )
+        format_walker()
+        used_vars = format_walker.used_vars
 
     if options.get_cache is not None:
         cache = {
@@ -381,24 +425,6 @@ def read_vars(vars_file):
                             else:
                                 exit(1)
 
-                elif interpreter["name"] == 'environment':  # pragma: nocover
-                    def action(value):
-                        if value is None:
-                            return os.environ
-                        else:
-                            try:
-                                return os.environ[value]
-                            except KeyError:
-                                error = \
-                                    "ERROR when getting {!r} in environment variables, " \
-                                    "possible values are: {!r}".format(
-                                        value, os.environ.keys()
-                                    )
-                                print(error)
-                                if interpreter.get("ignore_error", False):
-                                    return error
-                                else:
-                                    exit(1)
                 elif interpreter["name"] == 'json':
                     def action(value):
                         try:

--- a/c2c/tests/config.yaml
+++ b/c2c/tests/config.yaml
@@ -6,6 +6,6 @@ vars:
     dd.ee: '{DD_EE}'
 
 environment:
-- aa
-- bb.cc
-- dd\.ee
+- AA
+- BB_CC
+- DD_EE

--- a/c2c/tests/loop.yaml
+++ b/c2c/tests/loop.yaml
@@ -1,0 +1,8 @@
+vars:
+
+    aa: '{AA}'
+    bb: '{aa}'
+    cc: '{aa} {bb}'
+
+environment:
+- AA

--- a/c2c/tests/run-env.yaml
+++ b/c2c/tests/run-env.yaml
@@ -1,21 +1,22 @@
 vars:
-    aa: '{{AA}}'
+    aa: '{AA}'
     bb:
-        cc: '{{BB_CC}}'
+        cc: '{BB_CC}'
     dd:
-        ee: '{{DD_EE}}'
-    ff: ee{{FF}}gg
+        ee: '{DD_EE}'
+    ff: ee{FF}gg
     gg:
-    - name: ee{{GG}}gg
-    - name: hh{{GG}}ii
+    - name: ee{GG}gg
+    - name: hh{GG}ii
     hh:
-    - ee{{HH}}gg
-    - hh{{HH}}ii
+    - ee{HH}gg
+    - hh{HH}ii
+    ii: '11 {aa} 11'
 
 runtime_environment:
-- aa
-- bb.cc
-- dd\.ee
-- ff
-- gg.[].name
-- hh.[]
+- AA
+- BB_CC
+- DD_EE
+- FF
+- GG
+- HH

--- a/c2c/tests/template.in
+++ b/c2c/tests/template.in
@@ -1,3 +1,0 @@
-var1: ${var1}, var2: ${var2}
-var3: ${var3}
-var_interpreted: ${var_interpreted}

--- a/c2c/tests/test_template.py
+++ b/c2c/tests/test_template.py
@@ -33,7 +33,6 @@ import sys
 import yaml
 from six import StringIO
 from unittest import TestCase
-from nose.plugins.attrib import attr
 
 
 class TestTemplate(TestCase):
@@ -71,22 +70,6 @@ class TestTemplate(TestCase):
             'var1: first, var2: second\n'
             'var3: first, second, third\n'
             'var_interpreted: 4\n'
-        )
-
-    @attr(template=True)
-    def test_template(self):  # pragma: nocover
-        from c2c.template import main
-        sys.argv = [
-            '', '--engine', 'template', '--vars', 'c2c/tests/vars.yaml',
-            '--files', 'c2c/tests/template.in'
-        ]
-        main()
-
-        self.assertEquals(
-            open('c2c/tests/template', 'r').read(),
-            'var1: first, var2: second'
-            'var3: first, second, third'
-            'var_interpreted: 4'
         )
 
     def test_get_var(self):

--- a/c2c/tests/vars.yaml
+++ b/c2c/tests/vars.yaml
@@ -27,8 +27,3 @@ interpreted:
     node:
         vars: ["pi"]
         cmd: ["node", "-e"]
-
-runtime_environment:
-- aa
-- bb.cc
-- dd\.ee

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ install_requires = [
 
 setup(
     name='c2c.template',
-    version='1.6.0',
+    version='2.0.0',
     description='Vars collector and template runner.',
     long_description=README,
     namespace_packages=['c2c'],


### PR DESCRIPTION
Rework on environment and runtime environment

Now we don't need anymore to double the bracket for the environment variable: `{{AA}}` => `{AA}`
Stronger on replace loop
In environment and in runtime environment we specify the environment variable, no more the paths...