### PR TITLE
Fix update_vars mutating shared objects from YAML aliases

### DIFF
--- a/c2c/template/__init__.py
+++ b/c2c/template/__init__.py
@@ -438,6 +438,7 @@ def read_vars(vars_file: str) -> tuple[dict[str, Any], dict[str, Any]]:
     current_vars: dict[str, Any] = {}
     if "extends" in used:
         current_vars, config = read_vars(used["extends"])
+        current_vars = copy.deepcopy(current_vars)
 
         no_interpreted = set()
         no_interpreted.update(config.get("no_interpreted", []))

--- a/c2c/tests/alias_const.yaml
+++ b/c2c/tests/alias_const.yaml
@@ -1,0 +1,9 @@
+vars:
+  interfaces:
+    section_a:
+      options: &options
+        map: {}
+    section_b:
+      options: *options
+    section_c:
+      options: *options

--- a/c2c/tests/alias_project.yaml
+++ b/c2c/tests/alias_project.yaml
@@ -1,0 +1,17 @@
+extends: c2c/tests/alias_const.yaml
+
+update_paths:
+  - interfaces.section_b.options.map
+
+vars:
+  interfaces:
+    section_a:
+      options: &options
+        map: {}
+    section_b:
+      options:
+        <<: *options
+        map:
+          key: value
+    section_c:
+      options: *options

--- a/c2c/tests/test_template.py
+++ b/c2c/tests/test_template.py
@@ -564,6 +564,18 @@ class TestTemplate(TestCase):
         with open("c2c/tests/env.tmpl") as f:
             assert f.read() == "${AA}\n"
 
+    def test_yaml_alias_isolation(self):
+        from c2c.template import main
+
+        sys.argv = ["", "--vars", "c2c/tests/alias_project.yaml", "--get-config", "config7.yaml", "interfaces"]
+        main()
+
+        with open("config7.yaml") as config:
+            interfaces = yaml.safe_load(config.read())["vars"]["interfaces"]
+        assert interfaces["section_b"]["options"]["map"] == {"key": "value"}
+        assert interfaces["section_a"]["options"]["map"] == {}
+        assert interfaces["section_c"]["options"]["map"] == {}
+
     def test_include_cache(self):
         import c2c.template
 

--- a/c2c/tests/test_template.py
+++ b/c2c/tests/test_template.py
@@ -567,7 +567,14 @@ class TestTemplate(TestCase):
     def test_yaml_alias_isolation(self):
         from c2c.template import main
 
-        sys.argv = ["", "--vars", "c2c/tests/alias_project.yaml", "--get-config", "config7.yaml", "interfaces"]
+        sys.argv = [
+            "",
+            "--vars",
+            "c2c/tests/alias_project.yaml",
+            "--get-config",
+            "config7.yaml",
+            "interfaces",
+        ]
         main()
 
         with open("config7.yaml") as config:


### PR DESCRIPTION
When a parent vars file uses YAML anchors/aliases, multiple keys can reference the same Python dict object. update_vars() mutates dicts in-place, so merging a value into one section would silently bleed into all other sections sharing the same object.

Fix by deep-copying current_vars after loading the parent file, so aliases become independent copies before any mutation occurs.

Adds a regression test covering the alias isolation case.